### PR TITLE
リージョンをバージニア北部から東京に変更した

### DIFF
--- a/stg-infrastructure/terraform.tf
+++ b/stg-infrastructure/terraform.tf
@@ -24,5 +24,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-east-1"
+  region = "ap-northeast-1"
 }


### PR DESCRIPTION
## Overview

タイトルの通り､リージョンをバージニア北部から東京に変更した｡

さくらのVPSが石狩にあるかつ､サーバーレスなのであまりお金がかからないことから東京にしても問題がない｡